### PR TITLE
Fixes markdown syntax in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.4.1
 
-# Uses through2
-# Fixes gulp-utils dependency
-# Fixes "Writing a gulp plugin" links
+* Uses through2
+* Fixes gulp-utils dependency
+* Fixes "Writing a gulp plugin" links
 
 Thanks to @mikaelbr
 


### PR DESCRIPTION
Quick fix for markdown syntax in `CHANGELOG.md`. Using unordered list instead of a set of header 1s.
