### PR TITLE
Fixed coverall badge in the _README.md template.

### DIFF
--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -1,7 +1,7 @@
 (PLUGIN AUTHOR: Please read [Plugin README conventions](https://github.com/wearefractal/gulp/wiki/Plugin-README-Conventions), then delete this line)
 
 # <%= appname %>
-[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url]  [![Coverage Status](coveralls-image)](coveralls-url) [![Dependency Status][depstat-image]][depstat-url]
+[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url]  [![Coverage Status][coveralls-image]][coveralls-url] [![Dependency Status][depstat-image]][depstat-url]
 
 > <%= pluginName %> plugin for [gulp](https://github.com/wearefractal/gulp)
 


### PR DESCRIPTION
Small fix to make the coverall badge work in the `_README.md` template.

Thanks for the great generator, I've used it for all the gulp plugins I have created!
