### PR TITLE
Add jshint validthis:true directive

### DIFF
--- a/app/templates/index.js
+++ b/app/templates/index.js
@@ -12,6 +12,7 @@ module.exports = function (param) {
 	// see "Writing a plugin"
 	// https://github.com/gulpjs/gulp/blob/master/docs/writing-a-plugin/README.md
 	function <%= pluginNameCamel %>(file, enc, callback) {
+		/*jshint validthis:true*/
 
 		// Do nothing if no contents
 		if (file.isNull()) {


### PR DESCRIPTION
JSHint complains about the use of `this` inside the main plugin function, saying "Possible strict mode violation", because it's not clear that this function is going to have a specific context bound to it.

You could add `"validthis": true` in the `jshintrc`, but seeing as the issue is specific to this function definition, I suggest just adding it inline. (NB. you can't do `/*jshint validthis:true*/` at the top of a file; interestingly it [only works inside a function](http://jslinterrors.com/option-validthis-cant-be-used-in-a-global-scope/).)
